### PR TITLE
[AEA-40] Create book.model.js

### DIFF
--- a/backend/models/book.model.js
+++ b/backend/models/book.model.js
@@ -26,7 +26,6 @@ const bookSchema = new mongoose.Schema({
         trim: true,
         minlength: 10,
         maxlength: 13,
-        unique: true
     },
     genre: {
         type: String,

--- a/backend/models/book.model.js
+++ b/backend/models/book.model.js
@@ -1,0 +1,64 @@
+import mongoose from "mongoose"
+
+const bookSchema = new mongoose.Schema({
+    title: {
+        type: String,
+        required: true,
+        trim: true,
+        minlength: 1,
+        maxlength: 200,
+    },
+    author: {
+        type: String,
+        required: true,
+        trim: true,
+        minlength: 1,
+        maxlength: 100,
+    },
+    publicationDate: {
+        type: Date,
+        required: false
+    },
+    ISBN: { // International Standard Book Number and is 10 or 13 characters long
+        type: String,
+        required: true,
+        unique: true, // ensures ISBN is unique across all books
+        trim: true,
+        minlength: 10,
+        maxlength: 13,
+        unique: true
+    },
+    genre: {
+        type: String,
+        required: false,
+        trim: true,
+        minlength: 1,
+        maxlength: 50
+    },
+    description: {
+        type: String,
+        required: false,
+        trim: true,
+        minlength: 1,
+        maxlength: 1000
+    },
+    fileSize: {
+        type: Number, // size in bytes
+        required: false, 
+        min: 0 // file size cannot be negative
+    }
+}, {
+    timestamps: true // automatically adds createdAt and updatedAt fields
+})
+
+const Book = mongoose.model("Book", bookSchema) // Create the Book model using the bookSchema
+export default Book 
+
+/*
+created book schema with fields
+title, author, publicationDate, ISBN, genre, description
+and timestamps for createdAt and updatedAt.
+This schema can be used to create, read, update, and delete book records in a MongoDB database.
+I didn't include a user reference here, as the book model is independent of users.
+I also didn't create ID fields, as Mongoose automatically creates an _id field for each document.
+*/ 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1876,9 +1876,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1353,10 +1353,11 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"


### PR DESCRIPTION
Summary:
Created the Book schema and set up the foundational structure for PDF model integration.

Defined core fields including title, author, publicationDate, ISBN, genre, and description.
Enabled timestamps for createdAt and updatedAt.

Did not include user references, as this model is independent of user data.
Relied on Mongoose's default _id handling.

Why this change was necessary:
This schema establishes a standardized data model for storing and managing book records.
It lays the groundwork for CRUD operations and PDF document processing in the app’s backend.

Jira Reference:
Closes AEA-40