### PR TITLE
[AEA-47] Add explainText controller using OpenAI

### DIFF
--- a/backend/controllers/gpt.controller.js
+++ b/backend/controllers/gpt.controller.js
@@ -1,9 +1,9 @@
-import OpenAi from 'openai'; // 
+import OpenAI from 'openai'; // 
 import dotenv from 'dotenv';
 
 dotenv.config(); // Load environment variables from .env file
 
-const openai = new OpenAi({
+const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY, // Use the OpenAI API key from environment variables
 });
 

--- a/backend/controllers/gpt.controller.js
+++ b/backend/controllers/gpt.controller.js
@@ -1,0 +1,49 @@
+import OpenAi from 'openai'; // 
+import dotenv from 'dotenv';
+
+dotenv.config(); // Load environment variables from .env file
+
+const openai = new OpenAi({
+  apiKey: process.env.OPENAI_API_KEY, // Use the OpenAI API key from environment variables
+});
+
+/*
+ - controller function to handle text explanation requests using OpenAI's GPT model.
+ - It receives a text input from the request body, validates it, and sends it to the OpenAI API for processing.
+ - If the text is valid, it constructs a prompt to explain the text in simple terms.
+ - The response from OpenAI is then returned as a JSON object containing the explanation.
+ - If the text is invalid or if there is an error during the API call, appropriate error responses are sent back to the client.
+ - This function is designed to be used in an Express.js
+ */ 
+
+export const explainText = async (req, res) => {
+    const { text } = req.body; // Extract the text to be explained from the request body
+
+    if (!text || typeof text !== 'string' || text.trim() === '') {
+        return res.status(400).json({ error: 'Invalid text provided' }); // Return an error if the text is invalid
+    }
+
+    try {
+        // send the prompt to OpenAI's Chat completion API
+        const completion = await openai.chat.completions.create({
+            model: 'gpt-4-turbo', // Specify the model to use
+            messages: [
+                {
+                    role: 'system',
+                    content: 'You are a helpful assistant that explains text in simple terms.',
+                },
+                {
+                    role: 'user',
+                    content: `Explain the following text in simple terms:\n\n${text}`,
+                },
+            ],
+    });
+
+    const explanation = completion.choices[0]?.message?.content?.trim();
+
+    return res.status(200).json({ explanation }); // Return the explanation in the response
+} catch (error) {
+    console.error('Error from OpenAI:', error); // Log the error for debugging
+    return res.status(500).json({ error: 'Failed to get explanation from GPT' }); // Return a server error response
+    }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,8 @@
         "@emotion/styled": "^11.14.0",
         "@mui/material": "^7.1.0",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^7.6.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -2008,6 +2009,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -3066,6 +3076,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.3.tgz",
+      "integrity": "sha512-zf45LZp5skDC6I3jDLXQUu0u26jtuP4lEGbc7BbdyxenBN1vJSTA18czM2D+h5qyMBuMrD+9uB+mU37HIoKGRA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.3.tgz",
+      "integrity": "sha512-DiWJm9qdUAmiJrVWaeJdu4TKu13+iB/8IEi0EW/XgaHCjW/vWGrwzup0GVvaMteuZjKnh5bEvJP/K0MDnzawHw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.6.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -3166,6 +3214,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
     "@emotion/styled": "^11.14.0",
     "@mui/material": "^7.1.0",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^7.6.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",


### PR DESCRIPTION
**Summary:**
Added gpt.controller.js with an explainText controller that takes a string input from req.body.text and returns a simplified explanation using the OpenAI GPT-4-turbo API.

**Why this change was necessary:**
This controller provides the core functionality for our GPT-based feature. It will be used in the upcoming /gpt/explain route.

**Jira Reference:**
Closes AEA-47

**Reviewers:**
@denvercude 